### PR TITLE
Retornar formulário de escala no primeiro acesso.

### DIFF
--- a/backend/src/controllers/AcessosController.ts
+++ b/backend/src/controllers/AcessosController.ts
@@ -19,7 +19,7 @@ class AcessosController{
                 const timeDiff = Math.abs(new Date().getTime() - bebe.data_parto.getTime())
                 const diffDays =  Math.ceil(timeDiff/(1000 * 3600 * 24))
 
-                if(mae.acessos_app > 1 && mae.score_1d == null){
+                if(mae.acessos_app >= 1 && mae.score_1d == null){
                     return res.send({acao:"1D"})
                 }else if(diffDays >= 15 && mae.score_15d == null){
                     return res.send({acao:"15D"})


### PR DESCRIPTION
Como o backend só retorna a ação "1D" após o usuário acessar o app uma vez o formulário não fica disponível após o cadastro. Alterar a condição para ">=" evita esse problema.